### PR TITLE
Route tracer invalid-state panics through a context-rich reporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this
 project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+* Invalid-state panics in the tracer now route through a common `panic_invalid_state` sink that enriches the message with the active block (number + hash), transaction (hash + index) and call (index), plus a snapshot of the state flags (`init`, `in_block`, `in_transaction`, `in_call`, `in_system_call`) and the failing guard's `caller=` location — making "expected to be in block state" failures pinpoint the offending block/trx/call.
+
 ## v5.2.1
 
 * Flashblocks: offset tx index / cumulative gas / log block_index (without this, they always restart at 0 between partial blocks)

--- a/firehose-tracer-test/tests/tracer_invalid_state_panic_test.rs
+++ b/firehose-tracer-test/tests/tracer_invalid_state_panic_test.rs
@@ -1,0 +1,69 @@
+//! Tests for the common `panic_invalid_state` reporting path.
+//!
+//! Every invalid-state / broken-invariant panic in the tracer is routed through
+//! a single method that enriches the message with the position we were at (block,
+//! transaction, call) plus a snapshot of the boolean state flags. These tests lock
+//! in that enrichment so the debuggability never silently regresses.
+
+use firehose_tracer_test::{test_block, test_legacy_trx, TracerTester};
+
+/// Runs `f`, expecting it to panic, and returns the panic payload as a string.
+/// The default panic hook is muted for the duration so the (expected) panic does
+/// not pollute the test output.
+fn capture_panic(f: impl FnOnce()) -> String {
+    let previous_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(|_| {}));
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(f));
+    std::panic::set_hook(previous_hook);
+
+    let payload = result.expect_err("expected the call to panic but it did not");
+    payload
+        .downcast_ref::<String>()
+        .map(String::as_str)
+        .or_else(|| payload.downcast_ref::<&str>().copied())
+        .expect("panic payload was not a string")
+        .to_string()
+}
+
+#[test]
+fn panic_invalid_state_reports_state_flags_without_block() {
+    // Fresh, initialized tracer that is not in any block: the guard must still
+    // report the boolean state flags so the failure is self-describing.
+    let tester = TracerTester::new();
+
+    let message = capture_panic(|| {
+        tester.tracer.ensure_in_block();
+    });
+
+    assert!(
+        message.contains("caller expected to be in block state but we were not"),
+        "got: {message}"
+    );
+    assert!(message.contains("init=true"), "got: {message}");
+    assert!(message.contains("in_block=false"), "got: {message}");
+    assert!(message.contains("in_transaction=false"), "got: {message}");
+    // The caller location must point at the failing guard, not at the common sink.
+    assert!(message.contains("caller="), "got: {message}");
+}
+
+#[test]
+fn panic_invalid_state_reports_block_and_transaction_context() {
+    // Drive the tracer into block + transaction state, then trip a guard so we can
+    // assert the panic carries the block number/hash and the transaction.
+    let mut tester = TracerTester::new();
+    tester.start_block_trx(test_legacy_trx());
+
+    let message = capture_panic(|| {
+        // OnSkippedBlock while in a transaction is an invalid state.
+        tester.tracer.on_skipped_block(test_block());
+    });
+
+    assert!(
+        message.contains("skipped blocks must have 0 transactions"),
+        "got: {message}"
+    );
+    assert!(message.contains("at block #"), "got: {message}");
+    assert!(message.contains("in transaction "), "got: {message}");
+    assert!(message.contains("in_block=true"), "got: {message}");
+    assert!(message.contains("in_transaction=true"), "got: {message}");
+}

--- a/firehose-tracer/src/tracer.rs
+++ b/firehose-tracer/src/tracer.rs
@@ -288,7 +288,7 @@ impl Tracer {
                 node_version,
             );
         } else {
-            panic!("OnBlockchainInit was called more than once");
+            self.panic_invalid_state("OnBlockchainInit was called more than once");
         }
 
         firehose_info!("tracer initialized (chain_id={})", chain_config.chain_id);
@@ -614,8 +614,8 @@ impl Tracer {
     pub fn on_skipped_block(&mut self, event: BlockEvent) {
         // Validate we're not in a transaction (skipped blocks should never have transactions)
         if self.transaction.is_some() {
-            panic!(
-                "OnSkippedBlock called while in transaction state - skipped blocks must have 0 transactions"
+            self.panic_invalid_state(
+                "OnSkippedBlock called while in transaction state - skipped blocks must have 0 transactions",
             );
         }
 
@@ -1722,10 +1722,10 @@ impl Tracer {
             if snap.block.number == block_number {
                 // Same block number: flash block index must strictly advance
                 if fb.idx <= snap.flash_index {
-                    panic!(
+                    self.panic_invalid_state(format!(
                         "flash block index must be strictly greater than previous: block={} last_idx={} new_idx={}",
                         block_number, snap.flash_index, fb.idx
-                    );
+                    ));
                 }
             } else {
                 // Different block number: discard stale snapshot
@@ -1822,7 +1822,10 @@ impl Tracer {
             return;
         }
 
-        let block = self.block.as_ref().expect("must be in block state");
+        let block = match self.block.as_ref() {
+            Some(block) => block,
+            None => self.panic_invalid_state("must be in block state to snapshot flash block"),
+        };
 
         self.snapshot_for_next_flash_block = Some(FlashBlockSnapshot {
             block: block.clone(),
@@ -1953,9 +1956,56 @@ impl Tracer {
     // State Validation Methods
     // ============================================================================
 
+    /// Common sink for every invalid-state / broken-invariant panic in the tracer.
+    ///
+    /// On top of the caller-supplied `message`, it appends the position we were at
+    /// when the invariant broke — the block (number + hash), the transaction (hash +
+    /// index) and the active call (index) — plus a snapshot of the boolean state
+    /// flags. This turns an opaque "expected to be in block state" into something
+    /// that pinpoints the offending block/trx/call, which is the whole point.
+    ///
+    /// `#[track_caller]` is the Rust equivalent of the Go port's `callerSkip`
+    /// argument: it makes [`std::panic::Location::caller`] (and the panic location
+    /// itself) point at the `panic_invalid_state` call site rather than at this
+    /// method, so the reported `caller=` is the guard that actually failed.
+    ///
+    /// Mirrors `panicInvalidState` from `streamingfast/evm-firehose-tracer-go`.
+    #[track_caller]
+    fn panic_invalid_state(&self, message: impl std::fmt::Display) -> ! {
+        let caller = std::panic::Location::caller();
+
+        let mut context = String::new();
+        if let Some(block) = &self.block {
+            context.push_str(&format!(
+                " at block #{} ({})",
+                block.number,
+                hex::encode(&block.hash)
+            ));
+        }
+        if let Some(transaction) = &self.transaction {
+            context.push_str(&format!(
+                " in transaction {} (index {})",
+                hex::encode(&transaction.hash),
+                transaction.index
+            ));
+        }
+        if let Some(call) = self.call_stack.peek() {
+            context.push_str(&format!(" in call (index {})", call.index));
+        }
+
+        panic!(
+            "{message}{context} (caller={caller}, init={}, in_block={}, in_transaction={}, in_call={}, in_system_call={})",
+            self.chain_config.is_some(),
+            self.block.is_some(),
+            self.transaction.is_some(),
+            self.call_stack.has_active_call(),
+            self.in_system_call,
+        );
+    }
+
     fn ensure_blockchain_init(&self) {
         if self.chain_config.is_none() {
-            panic!("the OnBlockchainInit hook should have been called at this point");
+            self.panic_invalid_state("the OnBlockchainInit hook should have been called at this point");
         }
     }
 
@@ -1976,52 +2026,54 @@ impl Tracer {
 
     pub fn ensure_in_block(&self) {
         if self.block.is_none() {
-            panic!("caller expected to be in block state but we were not");
+            self.panic_invalid_state("caller expected to be in block state but we were not");
         }
     }
 
     fn ensure_in_block_and_in_trx(&self) {
         self.ensure_in_block();
         if self.transaction.is_none() {
-            panic!("caller expected to be in transaction state but we were not");
+            self.panic_invalid_state("caller expected to be in transaction state but we were not");
         }
     }
 
     fn ensure_in_block_and_not_in_trx(&self) {
         self.ensure_in_block();
         if self.transaction.is_some() {
-            panic!("caller expected to not be in transaction state but we were");
+            self.panic_invalid_state("caller expected to not be in transaction state but we were");
         }
     }
 
     fn ensure_in_block_and_not_in_trx_and_not_in_call(&self) {
         self.ensure_in_block();
         if self.transaction.is_some() {
-            panic!("caller expected to not be in transaction state but we were");
+            self.panic_invalid_state("caller expected to not be in transaction state but we were");
         }
         if self.call_stack.has_active_call() {
-            panic!("caller expected to not be in call state but we were");
+            self.panic_invalid_state("caller expected to not be in call state but we were");
         }
     }
 
     fn ensure_in_block_or_trx(&self) {
         if self.transaction.is_none() && self.block.is_none() {
-            panic!("caller expected to be in either block or transaction state but we were not");
+            self.panic_invalid_state(
+                "caller expected to be in either block or transaction state but we were not",
+            );
         }
     }
 
     fn ensure_in_block_and_in_trx_and_in_call(&self) {
         if self.transaction.is_none() || self.block.is_none() {
-            panic!("caller expected to be in block and in transaction but we were not");
+            self.panic_invalid_state("caller expected to be in block and in transaction but we were not");
         }
         if !self.call_stack.has_active_call() {
-            panic!("caller expected to be in call state but we were not");
+            self.panic_invalid_state("caller expected to be in call state but we were not");
         }
     }
 
     fn ensure_in_system_call(&self) {
         if !self.in_system_call {
-            panic!("caller expected to be in system call state but we were not");
+            self.panic_invalid_state("caller expected to be in system call state but we were not");
         }
     }
 


### PR DESCRIPTION
## What

Every invalid-state / broken-invariant panic in the Firehose tracer now routes through a single common reporter, `panic_invalid_state`, that enriches the message with the position we were at when the invariant broke:

- **block** — number + hash
- **transaction** — hash + index
- **call** — index
- **state flags** — `init`, `in_block`, `in_transaction`, `in_call`, `in_system_call`
- **caller location** — the failing guard's `file:line`, via `#[track_caller]` (the Rust equivalent of the Go port's `callerSkip`)

This turns an opaque `caller expected to be in block state but we were not` into a message that pinpoints the offending block/trx/call.

Mirrors `panicInvalidState` from [`streamingfast/evm-firehose-tracer-go`](https://github.com/streamingfast/evm-firehose-tracer-go/blob/master/tracer.go#L1901).

## Scope

Routed all tracer-position state guards (the `ensure_*` family, `OnBlockchainInit` double-init, `OnSkippedBlock` while in a transaction, flash-block index regression, and the flash-block snapshot block-state check).

Left as plain `panic!` (deliberately): four sites that either wrap an inner error or run after the transaction has been moved out of `self`, so `panic_invalid_state` could not add block/trx context there anyway (two deferred-state error wraps, two static log-mismatch invariant checks on a locally-assembled trx).

## Tests

Added `tracer_invalid_state_panic_test.rs` asserting the enriched message: state flags + caller location with no block, and block + transaction context when in a transaction. Full tracer suite passes.